### PR TITLE
Make sure downstream doesn't close sv1 server channels on its disconnection

### DIFF
--- a/roles/new-tproxy/src/lib/mod.rs
+++ b/roles/new-tproxy/src/lib/mod.rs
@@ -148,28 +148,28 @@ impl TranslatorSv2 {
                         break;
                     }
                     message = status_receiver.recv() => {
-                        error!("I received some error: {message:?}");
                         match message {
                             Ok(status) => {
                                 match status.state {
                                     State::DownstreamShutdown{downstream_id,..} => {
+                                        warn!("Downstream {downstream_id:?} disconnected, signalling sv1 server");
                                         notify_shutdown_clone.send(ShutdownMessage::DownstreamShutdown(downstream_id)).unwrap();
                                     }
                                     State::Sv1ServerShutdown(_) => {
+                                        warn!("Sv1 Server send shutdown signal");
                                         notify_shutdown_clone.send(ShutdownMessage::ShutdownAll).unwrap();
                                         break;
                                     }
                                     State::ChannelManagerShutdown(_) => {
+                                        warn!("Channel manager send shutdown signal");
                                         notify_shutdown_clone.send(ShutdownMessage::ShutdownAll).unwrap();
                                         break;
                                     }
                                     State::UpstreamShutdown(_) => {
+                                        warn!("Upstream send shutdown signal");
                                         notify_shutdown_clone.send(ShutdownMessage::ShutdownAll).unwrap();
                                         break;
                                     }
-                                    State::Healthy(_) => {
-                                    }
-
                                 }
                             }
                             _ => {}

--- a/roles/new-tproxy/src/lib/status.rs
+++ b/roles/new-tproxy/src/lib/status.rs
@@ -55,8 +55,6 @@ pub enum State {
     ChannelManagerShutdown(TproxyError),
     /// Upstream SV2 connection closed or failed.
     UpstreamShutdown(TproxyError),
-    /// Component is healthy and operating as expected.
-    Healthy(String),
 }
 
 /// A message reporting the current [`State`] of a component.

--- a/roles/new-tproxy/src/lib/sv1/downstream/channel.rs
+++ b/roles/new-tproxy/src/lib/sv1/downstream/channel.rs
@@ -31,6 +31,5 @@ impl DownstreamChannelState {
         debug!("Dropping downstream channel state");
         self.downstream_sv1_receiver.close();
         self.downstream_sv1_sender.close();
-        self.sv1_server_sender.close();
     }
 }

--- a/roles/new-tproxy/src/lib/sv1/sv1_server/sv1_server.rs
+++ b/roles/new-tproxy/src/lib/sv1/sv1_server/sv1_server.rs
@@ -283,7 +283,8 @@ impl Sv1Server {
                         status_sender,
                     );
 
-                    // this is done to make sure that the job is sent after the initial handshake (subscribe, authorize, etc.) is done
+                    // this is done to make sure that the job is sent after the initial handshake
+                    // (subscribe, authorize, etc.) is done
                     time::sleep(Duration::from_secs(1)).await;
                     let set_difficulty = get_set_difficulty(first_target).map_err(|_| {
                         TproxyError::General("Failed to generate set_difficulty".into())

--- a/roles/new-tproxy/src/lib/sv2/channel_manager/message_handler.rs
+++ b/roles/new-tproxy/src/lib/sv2/channel_manager/message_handler.rs
@@ -218,7 +218,8 @@ impl ParseMiningMessagesFromUpstream<Downstream> for ChannelManagerData {
                     .write()
                     .unwrap();
                 upstream_extended_channel.on_new_extended_mining_job(m_static.clone());
-                m_static.channel_id = 0; // this is done so that every aggregated downstream will receive the NewExtendedMiningJob message
+                m_static.channel_id = 0; // this is done so that every aggregated downstream will
+                                         // receive the NewExtendedMiningJob message
             }
             self.extended_channels.iter().for_each(|(_, channel)| {
                 let mut channel = channel.write().unwrap();


### PR DESCRIPTION
With this and PR: https://github.com/stratum-mining/stratum/pull/1782, the panic should no longer occur, and the tproxy will no longer shut down entirely when the downstream disconnects.