### PR TITLE
Add upstream fallback

### DIFF
--- a/roles/new-tproxy/config-examples/tproxy-config-hosted-pool-example.toml
+++ b/roles/new-tproxy/config-examples/tproxy-config-hosted-pool-example.toml
@@ -3,11 +3,6 @@
 # upstream_address = "18.196.32.109"
 # upstream_port = 3336
 
-# Hosted SRI Pool Upstream Connection
-upstream_address = "75.119.150.111"
-upstream_port = 34254
-upstream_authority_pubkey = "9auqWEzQDVyd2oe1JVGFLMLHZtCo2FFqZwtKA5gd9xbuEu7PH72"
-
 # Local Mining Device Downstream Connection
 downstream_address = "0.0.0.0"
 downstream_port = 34255
@@ -35,3 +30,8 @@ aggregate_channels = true
 min_individual_miner_hashrate=10_000_000.0
 # target number of shares per minute the miner should be sending
 shares_per_minute = 6.0
+
+[[upstreams]]
+address = "75.119.150.111"
+port = 34254
+authority_pubkey = "9auqWEzQDVyd2oe1JVGFLMLHZtCo2FFqZwtKA5gd9xbuEu7PH72"

--- a/roles/new-tproxy/config-examples/tproxy-config-local-jdc-example.toml
+++ b/roles/new-tproxy/config-examples/tproxy-config-local-jdc-example.toml
@@ -3,11 +3,6 @@
 # upstream_address = "18.196.32.109"
 # upstream_port = 3336
 
-# Local SRI JDC Upstream Connection
-upstream_address = "127.0.0.1"
-upstream_port = 34265
-upstream_authority_pubkey = "9auqWEzQDVyd2oe1JVGFLMLHZtCo2FFqZwtKA5gd9xbuEu7PH72"
-
 # Local Mining Device Downstream Connection
 downstream_address = "0.0.0.0"
 downstream_port = 34255
@@ -35,3 +30,9 @@ aggregate_channels = true
 min_individual_miner_hashrate=10_000_000_000_000.0
 # target number of shares per minute the miner should be sending
 shares_per_minute = 6.0
+
+
+[[upstreams]]
+address = "127.0.0.1"
+port = 34265
+authority_pubkey = "9auqWEzQDVyd2oe1JVGFLMLHZtCo2FFqZwtKA5gd9xbuEu7PH72"

--- a/roles/new-tproxy/config-examples/tproxy-config-local-pool-example.toml
+++ b/roles/new-tproxy/config-examples/tproxy-config-local-pool-example.toml
@@ -3,11 +3,6 @@
 # upstream_address = "18.196.32.109"
 # upstream_port = 3336
 
-# Local SRI Pool Upstream Connection
-upstream_address = "127.0.0.1"
-upstream_port = 34254
-upstream_authority_pubkey = "9auqWEzQDVyd2oe1JVGFLMLHZtCo2FFqZwtKA5gd9xbuEu7PH72"
-
 # Local Mining Device Downstream Connection
 downstream_address = "0.0.0.0"
 downstream_port = 34255
@@ -35,3 +30,13 @@ aggregate_channels = true
 min_individual_miner_hashrate=10_000_000_000_000.0
 # target number of shares per minute the miner should be sending
 shares_per_minute = 6.0
+
+[[upstreams]]
+address = "127.0.0.1"
+port = 34254
+authority_pubkey = "9auqWEzQDVyd2oe1JVGFLMLHZtCo2FFqZwtKA5gd9xbuEu7PH72"
+
+[[upstreams]]
+address = "75.119.150.111"
+port = 34254
+authority_pubkey = "9auqWEzQDVyd2oe1JVGFLMLHZtCo2FFqZwtKA5gd9xbuEu7PH72"

--- a/roles/new-tproxy/src/lib/config.rs
+++ b/roles/new-tproxy/src/lib/config.rs
@@ -16,12 +16,7 @@ use serde::Deserialize;
 /// Configuration for the Translator.
 #[derive(Debug, Deserialize, Clone)]
 pub struct TranslatorConfig {
-    /// The address of the upstream server.
-    pub upstream_address: String,
-    /// The port of the upstream server.
-    pub upstream_port: u16,
-    /// The Secp256k1 public key used to authenticate the upstream authority.
-    pub upstream_authority_pubkey: Secp256k1PublicKey,
+    pub upstreams: Vec<Upstream>,
     /// The address for the downstream interface.
     pub downstream_address: String,
     /// The port for the downstream interface.
@@ -42,17 +37,18 @@ pub struct TranslatorConfig {
     /// If true, all miners share one channel. If false, each miner gets its own channel.
     pub aggregate_channels: bool,
 }
-/// Configuration settings specific to the upstream connection.
-pub struct UpstreamConfig {
+
+#[derive(Debug, Deserialize, Clone)]
+pub struct Upstream {
     /// The address of the upstream server.
-    address: String,
+    pub address: String,
     /// The port of the upstream server.
-    port: u16,
+    pub port: u16,
     /// The Secp256k1 public key used to authenticate the upstream authority.
-    authority_pubkey: Secp256k1PublicKey,
+    pub authority_pubkey: Secp256k1PublicKey,
 }
 
-impl UpstreamConfig {
+impl Upstream {
     /// Creates a new `UpstreamConfig` instance.
     pub fn new(address: String, port: u16, authority_pubkey: Secp256k1PublicKey) -> Self {
         Self {
@@ -88,7 +84,7 @@ impl TranslatorConfig {
     /// Creates a new `TranslatorConfig` instance by combining upstream and downstream
     /// configurations and specifying version and extranonce constraints.
     pub fn new(
-        upstream: UpstreamConfig,
+        upstreams: Vec<Upstream>,
         downstream: DownstreamConfig,
         max_supported_version: u16,
         min_supported_version: u16,
@@ -97,9 +93,7 @@ impl TranslatorConfig {
         aggregate_channels: bool,
     ) -> Self {
         Self {
-            upstream_address: upstream.address,
-            upstream_port: upstream.port,
-            upstream_authority_pubkey: upstream.authority_pubkey,
+            upstreams,
             downstream_address: downstream.address,
             downstream_port: downstream.port,
             max_supported_version,

--- a/roles/new-tproxy/src/lib/mod.rs
+++ b/roles/new-tproxy/src/lib/mod.rs
@@ -71,16 +71,19 @@ impl TranslatorSv2 {
         let (sv1_server_to_channel_manager_sender, sv1_server_to_channel_manager_receiver) =
             unbounded();
 
-        let upstream_addr = SocketAddr::new(
-            self.config.upstream_address.parse().unwrap(),
-            self.config.upstream_port,
-        );
-
-        info!("Connecting to upstream at: {}", upstream_addr);
+        let upstream_addresses = self
+            .config
+            .upstreams
+            .iter()
+            .map(|upstream| {
+                let upstream_addr =
+                    SocketAddr::new(upstream.address.parse().unwrap(), upstream.port);
+                (upstream_addr, upstream.authority_pubkey)
+            })
+            .collect::<Vec<_>>();
 
         let upstream = match Upstream::new(
-            upstream_addr,
-            self.config.upstream_authority_pubkey,
+            &upstream_addresses,
             upstream_to_channel_manager_sender.clone(),
             channel_manager_to_upstream_receiver.clone(),
             notify_shutdown.clone(),

--- a/roles/new-tproxy/src/lib/mod.rs
+++ b/roles/new-tproxy/src/lib/mod.rs
@@ -193,6 +193,7 @@ impl TranslatorSv2 {
                                                     notify_shutdown_clone.send(ShutdownMessage::ShutdownAll).unwrap();
                                                     break;
                                                 } else {
+                                                    notify_shutdown_clone.send(ShutdownMessage::DownstreamShutdownAll).unwrap();
                                                     info!("Upstream restarted successfully.");
                                                 }
                                             }

--- a/roles/new-tproxy/src/lib/sv1/downstream/downstream.rs
+++ b/roles/new-tproxy/src/lib/sv1/downstream/downstream.rs
@@ -78,6 +78,10 @@ impl Downstream {
                                 info!("Downstream {downstream_id}: received targeted shutdown");
                                 break;
                             }
+                            Ok(ShutdownMessage::DownstreamShutdownAll) => {
+                                info!("All downstream shutdown message received");
+                                break;
+                            }
                             Ok(_) => {
                                 // shutdown for other downstream
                             }

--- a/roles/new-tproxy/src/lib/sv1/sv1_server/sv1_server.rs
+++ b/roles/new-tproxy/src/lib/sv1/sv1_server/sv1_server.rs
@@ -119,6 +119,10 @@ impl Sv1Server {
                                 info!("Downstream: {downstream_id} removed from sv1 server downstreams");
                             }
                         }
+                        Ok(ShutdownMessage::DownstreamShutdownAll) => {
+                            self.sv1_server_data.super_safe_lock(|d|{d.downstreams = HashMap::new();});
+                            info!("All downstream removed from sv1 server downstreams as upstream changed");
+                        }
                         _ => {}
                     }
                 }
@@ -414,6 +418,10 @@ impl Sv1Server {
                             if current_downstream.is_some() {
                                 info!("Downstream: {downstream_id} removed from sv1 server downstreams");
                             }
+                        }
+                        Ok(ShutdownMessage::DownstreamShutdownAll) => {
+                            self.sv1_server_data.super_safe_lock(|d|{d.downstreams = HashMap::new();});
+                            info!("All downstream removed from sv1 server downstreams as upstream changed");
                         }
                         _ => {}
                     }

--- a/roles/new-tproxy/src/lib/sv2/upstream/channel.rs
+++ b/roles/new-tproxy/src/lib/sv2/upstream/channel.rs
@@ -35,8 +35,6 @@ impl UpstreamChannelState {
 
     pub fn drop(&self) {
         debug!("Closing all upstream channels");
-        self.channel_manager_receiver.close();
-        self.channel_manager_sender.close();
         self.upstream_receiver.close();
         self.upstream_receiver.close();
     }

--- a/roles/new-tproxy/src/lib/utils.rs
+++ b/roles/new-tproxy/src/lib/utils.rs
@@ -164,5 +164,6 @@ pub fn into_static(m: AnyMessage<'_>) -> Result<AnyMessage<'static>, TproxyError
 #[derive(Debug, Clone)]
 pub enum ShutdownMessage {
     ShutdownAll,
+    DownstreamShutdownAll,
     DownstreamShutdown(u32),
 }


### PR DESCRIPTION
This PR adds upstream fallback support. The configuration now accepts multiple upstreams. 
The tproxy can fall back to a different upstream if one becomes unavailable:

1. During the initial bootstrap of tproxy.
2. midway through operation, if the current upstream shuts down unexpectedly.

Additionally, this PR introduces a new ShutdownMessage variant, DownstreamShutdownAll, which disconnects all downstreams after an upstream change has occurred.
